### PR TITLE
Update mfrc522.py

### DIFF
--- a/mfrc522.py
+++ b/mfrc522.py
@@ -30,7 +30,7 @@ class MFRC522:
 			self.spi = SPI(0)
 			self.spi.init(SPI.MASTER, baudrate=1000000, pins=(self.sck, self.mosi, self.miso))
 		elif board == 'esp8266':
-			self.spi = SPI(baudrate=100000, polarity=0, phase=0, sck=self.sck, mosi=self.mosi, miso=self.miso)
+			self.spi = SPI(baudrate=1000000, polarity=0, phase=0, sck=self.sck, mosi=self.mosi, miso=self.miso)
 			self.spi.init()
 		else:
 			raise RuntimeError("Unsupported platform")


### PR DESCRIPTION
Fixed the wrong SPI baudrate of ESP8266.
修正了错误的SPI速率。