### PR TITLE
add esp32 as supported plattform

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ For the ESP8266 there are multiple solutions to do that. E.g. use the
  
 I used the following pins for my setup:
 
-| Signal    | GPIO ESP8266 | GPIO WiPy      | Note                                 |
-| --------- | ------------ | -------------- | ------------------------------------ |
-| sck       | 0            | "GP14"         |                                      |
-| mosi      | 2            | "GP16"         |                                      |
-| miso      | 4            | "GP15"         |                                      |
-| rst       | 5            | "GP22"         |                                      |
-| cs        | 14           | "GP14"         |Labeled SDA on most RFID-RC522 boards |
+| Signal    | GPIO ESP8266 / ESP32 | GPIO WiPy      | Note                                 |
+| --------- | -------------------- | -------------- | ------------------------------------ |
+| sck       | 0                    | "GP14"         |                                      |
+| mosi      | 2                    | "GP16"         |                                      |
+| miso      | 4                    | "GP15"         |                                      |
+| rst       | 5                    | "GP22"         |                                      |
+| cs        | 14                   | "GP14"         |Labeled SDA on most RFID-RC522 boards |
  
 Now enter the REPL you could run one of the two exmaples: 
 

--- a/examples/read.py
+++ b/examples/read.py
@@ -6,7 +6,7 @@ def do_read():
 
 	if uname()[0] == 'WiPy':
 		rdr = mfrc522.MFRC522("GP14", "GP16", "GP15", "GP22", "GP17")
-	elif uname()[0] == 'esp8266':
+	elif uname()[0] == 'esp8266' or uname()[0] == 'esp32':
 		rdr = mfrc522.MFRC522(0, 2, 4, 5, 14)
 	else:
 		raise RuntimeError("Unsupported platform")

--- a/examples/write.py
+++ b/examples/write.py
@@ -6,7 +6,7 @@ def do_write():
 
 	if uname()[0] == 'WiPy':
 		rdr = mfrc522.MFRC522("GP14", "GP16", "GP15", "GP22", "GP17")
-	elif uname()[0] == 'esp8266':
+	elif uname()[0] == 'esp8266' or uname()[0] == 'esp32':
 		rdr = mfrc522.MFRC522(0, 2, 4, 5, 14)
 	else:
 		raise RuntimeError("Unsupported platform")

--- a/mfrc522.py
+++ b/mfrc522.py
@@ -29,7 +29,7 @@ class MFRC522:
 		if board == 'WiPy' or board == 'LoPy' or board == 'FiPy':
 			self.spi = SPI(0)
 			self.spi.init(SPI.MASTER, baudrate=1000000, pins=(self.sck, self.mosi, self.miso))
-		elif board == 'esp8266':
+		elif board == 'esp8266' or board == 'esp32':
 			self.spi = SPI(baudrate=100000, polarity=0, phase=0, sck=self.sck, mosi=self.mosi, miso=self.miso)
 			self.spi.init()
 		else:


### PR DESCRIPTION
I tried the examples on an ESP32 devkit and it worked as expected.

@wendlers should be possible to merge without any additional work - unlike the other two PR with the same topic.